### PR TITLE
fix: detect runner architecture when selecting shfmt artifact (#541)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,11 +70,17 @@ async function run(): Promise<void> {
       platform = "linux";
     }
 
-    let artifact = `shfmt_v${version}_${platform}_amd64`;
+    const archMap: Record<string, string> = { x64: "amd64", arm64: "arm64", arm: "arm", ia32: "386" };
+    const arch = archMap[process.arch];
+    if (!arch) {
+      throw new Error(`Unsupported architecture: ${process.arch}`);
+    }
+    let artifact = `shfmt_v${version}_${platform}_${arch}`;
 
-    if (process.platform === "win32") {
+    if (platform === "windows") {
       artifact += ".exe";
     }
+    core.info(`Resolved artifact name: ${artifact}`);
 
     const binPath = `${os.homedir}/bin`;
     await io.mkdirP(binPath);


### PR DESCRIPTION
- On arm64 runners, the action downloaded the amd64 shfmt binary, causing "Exec format error."
- This PR detects the runner's architecture and downloads the matching `shfmt` artefact.

Files changed:
- `src/index.ts`

Closes:
- #541